### PR TITLE
support string_val type on prometheus

### DIFF
--- a/gateway/exporters/prometheus/prometheus.go
+++ b/gateway/exporters/prometheus/prometheus.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"strconv"
 
 	"github.com/openconfig/gnmi/cache"
 	"github.com/openconfig/gnmi/ctree"
@@ -149,7 +150,12 @@ func GetNumberValues(tv *gnmipb.TypedValue) (float64, bool) {
 	if tv != nil && tv.Value != nil {
 		switch tv.Value.(type) {
 		case *gnmipb.TypedValue_StringVal:
-			return 0, false
+			tmpval, err := strconv.ParseFloat(tv.GetStringVal(), 64)
+			if err != nil {
+				return 0, false
+			} else {
+				return tmpval, true
+			}
 		case *gnmipb.TypedValue_IntVal:
 			return float64(tv.GetIntVal()), true
 		case *gnmipb.TypedValue_UintVal:


### PR DESCRIPTION
Sone network OS (e.g. SONiC) use `StringVal` type on update. like below.
`path:{elem:{name:\"COUNTERS\"} elem:{name:\"Ethernet3\"} elem:{name:\"SAI_PORT_STAT_IF_OUT_OCTETS\"}} val:{string_val:\"774306502487\"}`

below is SONiC's example data & docs.
- https://github.com/Azure/sonic-telemetry/tree/master/testdata
- https://github.com/Azure/sonic-telemetry/blob/master/doc/grpc_telemetry.md

So, if it can convert string_val  to float, I want to treat it normal data.
