### PR TITLE
State locking procedure changes.

### DIFF
--- a/gateway/connections/zookeeper.go
+++ b/gateway/connections/zookeeper.go
@@ -66,7 +66,9 @@ func (c *ZookeeperConnectionManager) eventListener(zkEvents <-chan zk.Event) {
 			for _, targetConfig := range c.connections {
 				if targetConfig.useLock {
 					err := targetConfig.unlock()
-					c.config.Log.Error().Msgf("error while unlocking target: %v", err)
+					if err != nil {
+						c.config.Log.Error().Msgf("error while unlocking target: %v", err)
+					}
 				}
 			}
 			c.connectionsMutex.Unlock()

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -425,7 +425,7 @@ func (g *Gateway) zookeeperEventHandler(zkEventChan <-chan zk.Event) {
 		switch event.State {
 		case zk.StateDisconnected:
 			disconnectedCount++
-			if disconnectedCount > 5 {
+			if disconnectedCount > 50 {
 				panic("too many Zookeeper disconnects")
 			}
 		case zk.StateHasSession:

--- a/gateway/locking/local.go
+++ b/gateway/locking/local.go
@@ -40,6 +40,10 @@ func NewNonBlockingLock(id string, member string) DistributedLocker {
 	}
 }
 
+func (l *NonBlockingLock) LockAcquired() bool {
+	return l.acquired
+}
+
 func (l *NonBlockingLock) GetMember(id string) (string, error) {
 	val, exists := registry.Load(id)
 	if exists {

--- a/gateway/locking/locker.go
+++ b/gateway/locking/locker.go
@@ -18,14 +18,16 @@ package locking
 // DistributedLocker is an interface for creating non-blocking locks
 // among distributed processes.
 type DistributedLocker interface {
+	// LockAcquired returns true if the lock is currently acquired.
+	LockAcquired() bool
 	// Try to acquire the lock. If the lock is already acquired return true and
 	// a deadlock error.
 	Try() (bool, error)
 	// Unlock the lock.
 	Unlock() error
-	// Return the ID for this lock.
+	// ID returns the ID or lock path for this lock.
 	ID() string
-	// Get the member that currently has the lock for the ID, if it's currently
+	// GetMember gets the member that currently has the lock for the provided ID, if it's currently
 	// locked, otherwise return an empty string.
 	GetMember(id string) (string, error)
 }


### PR DESCRIPTION
Improvements to the connection state locking procedure to help ensure that locks are cleaned up when released or disconnected. Note that there is a backwards incompatible change to the DistributedLocker interface.